### PR TITLE
MongoDB - Support for bulk read operation to prevent memory issues and criteria option to change cursor batch size

### DIFF
--- a/grails-datastore-gorm-mongodb/src/main/groovy/org/grails/datastore/gorm/mongo/MongoCriteriaBuilder.java
+++ b/grails-datastore-gorm-mongodb/src/main/groovy/org/grails/datastore/gorm/mongo/MongoCriteriaBuilder.java
@@ -16,10 +16,6 @@
 package org.grails.datastore.gorm.mongo;
 
 import grails.gorm.CriteriaBuilder;
-
-import java.util.List;
-import java.util.Map;
-
 import grails.mongodb.geo.Distance;
 import grails.mongodb.geo.GeoJSON;
 import grails.mongodb.geo.Point;
@@ -28,11 +24,14 @@ import org.grails.datastore.mapping.core.Session;
 import org.grails.datastore.mapping.mongo.query.MongoQuery;
 import org.grails.datastore.mapping.mongo.query.MongoQuery.Near;
 import org.grails.datastore.mapping.mongo.query.MongoQuery.WithinBox;
-import org.grails.datastore.mapping.mongo.query.MongoQuery.WithinPolygon;
 import org.grails.datastore.mapping.mongo.query.MongoQuery.WithinCircle;
+import org.grails.datastore.mapping.mongo.query.MongoQuery.WithinPolygon;
 import org.grails.datastore.mapping.query.Query;
 import org.grails.datastore.mapping.query.api.Criteria;
 import org.grails.datastore.mapping.query.api.QueryArgumentsAware;
+
+import java.util.List;
+import java.util.Map;
 
 /**
  * Extends the default CriteriaBuilder implementation with Geolocation methods
@@ -279,6 +278,24 @@ public class MongoCriteriaBuilder extends CriteriaBuilder {
 
     public Criteria arguments(Map arguments) {
         ((QueryArgumentsAware)this.query).setArguments(arguments);
+        return this;
+    }
+
+    /**
+     * Enable support for bulk read of database records to prevent Memory issues. For example:
+     * <pre>
+     *     User.withCriteria {
+     *         eq("enabled", true)
+     *         supportBulkOperation()
+     *     }
+     * </pre>
+     *
+     * @author Shashank Agrawal
+     * @since 3.1.6
+     * @since 4.0.7
+     */
+    public Criteria supportBulkOperation() {
+        ((MongoQuery)this.query).enableSupportForBulkOperation();
         return this;
     }
 }

--- a/grails-datastore-gorm-mongodb/src/test/groovy/org/grails/datastore/gorm/mongo/IndexAttributesAndCompoundKeySpec.groovy
+++ b/grails-datastore-gorm-mongodb/src/test/groovy/org/grails/datastore/gorm/mongo/IndexAttributesAndCompoundKeySpec.groovy
@@ -17,7 +17,11 @@ class IndexAttributesAndCompoundKeySpec extends GormDatastoreSpec{
             ServerStream.count() == 0
             ServerStream.collection.indexInfo[1].key == [server:1, stream:1]
             ServerStream.collection.indexInfo[1].unique
-            ServerStream.collection.indexInfo[1].dropDups
+            /*
+             * Commenting here as it is already fixed in commits of higher version.
+             * https://github.com/grails/grails-data-mapping/commit/5f9d3c59cd8f239cff6b8fd892c0feea2a3621f4#diff-07fd5c0f57b567949b54891341ebdb79L21
+             */
+            //ServerStream.collection.indexInfo[1].dropDups
 
     }
     @Override

--- a/grails-documentation-mongodb/src/docs/guide/3.10 Batching.gdoc
+++ b/grails-documentation-mongodb/src/docs/guide/3.10 Batching.gdoc
@@ -1,0 +1,70 @@
+GORM for MongoDB internally uses the underlying MongoDB Cursor which supports the notion of
+[batches|http://docs.mongodb.org/manual/core/cursors/#cursor-batches]. So the GORM allows some feature around it:
+
+h4. Batch Size
+
+According to the MongoDB cursor batch
+
+{note}
+The MongoDB server returns the query results in batches. Batch size will not exceed the maximum BSON document size.
+For most queries, the first batch returns 101 documents or just enough documents to exceed 1 megabyte. Subsequent
+batch size is 4 megabytes.
+{note}
+
+Consider a case where you have 50,000 records in a @User@ domain and you want to iterate over all users to send them
+an customized email. For example:
+
+{code}
+import com.user.User
+
+List<User> userInstanceList = User.withCriteria {
+    eq("enabled", true)
+}
+
+userInstanceList.each { userInstance ->
+     // send email to userInstance
+}
+{code}
+
+The above code might fetch the 100 records in each batch that means to iterate over these 50,000 records, your
+database will be hit 500 times which may be a database performance problem. So to avoid this, you can customize the
+batch size of underlying MongoDB cursor:
+
+{code}
+import com.user.User
+
+List<User> userInstanceList = User.withCriteria {
+    eq("enabled", true)
+    arguments([batchSize: 2000])
+}
+{code}
+
+h4. Batch Read Operation Support
+
+In the above described example, your server may end up in out of Memory error if your collection record size
+increases (based on the configured JVM_OPTS and RAM size). Because for every record you iterate will get cached in the
+underlying session and also in an internal @List@. This will start filling up the memory and will eventually blows up
+the RAM.
+
+To prevent this, modify your criteria to include another statement @supportBulkOperation()@
+
+{code}
+import com.user.User
+
+List<User> userInstanceList = User.withCriteria {
+    eq("enabled", true)
+    supportBulkOperation()
+}
+
+userInstanceList.each { userInstance ->
+     // send email to userInstance
+}
+{code}
+
+This criteria will now prevent GORM to cache any instance of the @User@ domain class. So the domain instance will be
+immediately eligible for GC after the end of the loop and this will allow to iterate over any large number of records
+without worrying about the memory.
+
+This feature will also prevent some of the method which can be called over @userInstanceList@ like @toString()@,
+@size()@, @userInstanceList\[100\]@ etc. and will throw @UnsupportedOperationException@ so that you can only use the
+Groovy's @each@ method on the @userInstanceList@.


### PR DESCRIPTION
This pull request is intended to discuss on the topic that **whether underlying MongoDB cursor in GORM can be used to iterate over a large collection of records to do various batch operations in a Grails app without writing a custom batch processor**.

This pull request consisting that change to support the same bulk read operation of domain records with preventing out of memory issues.

Considering an example where we are sending a customized email to 1,00,000 users stored in a MongoDB user collection or in a Grails `User` domain. To iterate over these number of records we will be needing a batch processor implementation to read and process the 1,00,000 records in batches in order to prevent memory issues.

But the MongoDB cursor already supports [batching](http://docs.mongodb.org/manual/core/cursors/#cursor-batches) so we can take advantage of this batching in the GORM for MongoDB. In the current implementation of GORM criteria processor, it stores every instance which are fetched from the criteria into the session and in an internal list [initializedObjects](https://github.com/grails/grails-data-mapping/blob/v3.1.5/grails-datastore-gorm-mongodb/src/main/groovy/org/grails/datastore/mapping/mongo/query/MongoQuery.java#L1781) to prevent re-fetching of instances from the database.

Also, calling some method like `toString()`, `size()`, `get()` over the instance of criteria also stores all the records in the memory and this will results in memory out of error. This pull request allows us to call another method in the criteria `supportBulkOperation()` which can prevent GORM to cache instances into the memory so the instances will be immediatly eligible for garbage collection.

``` groovy
List<User> userInstanceList = User.withCriteria {
    eq("enabled", true)
    arguments([batchSize: 2000])        // Another feature in the pull reqest to change batch size3
    supportBulkOperation()
}

userInstanceList.each { userInstance ->
     // send email to userInstance
}
```

Hence we can utilize the batching of MongoDB cursor in our Grails code without writing or using a batch processor implementation.

Below is the image of modified Grails MongoDB plugin documentation which describes the above said  example under the **Batch Read Operation Support** heading.

![image](https://cloud.githubusercontent.com/assets/1804514/10367450/326c03e8-6dee-11e5-82e2-07e3f02581a0.png)

To test this change, we created a `User` domain with 25,000 records in it and attached a Java profile to read the stats. Following are the snapshot of the number of heap instance of `User` domain class, memory graph and garbase colllector activity when not using the `supportBulkOperation()` feature:
### Before using the support feature:

![before-live-instance-count](https://cloud.githubusercontent.com/assets/1804514/10367817/2965a824-6df0-11e5-9e6e-20c269486fb4.png)
![before-memory-graph](https://cloud.githubusercontent.com/assets/1804514/10368381/8f9d129c-6df2-11e5-8fe4-6c79ef714f0f.png)
![before-gc-activity](https://cloud.githubusercontent.com/assets/1804514/10368388/960a6116-6df2-11e5-827f-008d5928c5bb.png)
## After using the support feature:

![after-live-instance-count](https://cloud.githubusercontent.com/assets/1804514/10368234/fb595186-6df1-11e5-8996-05463ff5c3be.png)
![after-gc-activity](https://cloud.githubusercontent.com/assets/1804514/10368241/00360a8c-6df2-11e5-8581-0d149099c528.png)
![after-memory-graph](https://cloud.githubusercontent.com/assets/1804514/10368243/04935e72-6df2-11e5-8405-a5c9516dddc7.png)

I've taken these snapshots when the loop reaches around 20,000th record which represents that when we do not use the bulk read support, all the instances resides in the heap and memory starts filling up. But if we use this feature, there are only few instances residing in the heap and hence safe to iterate over the large records.
